### PR TITLE
Fix git installation: correct repo URL and disable submodules

### DIFF
--- a/tasks/nvm.yml
+++ b/tasks/nvm.yml
@@ -188,8 +188,9 @@
         - name: Install via git
           ansible.builtin.git:
             dest: "{{ nvm_dir }}"
-            repo: 'https://github.com/creationix/nvm.git .nvm'
+            repo: 'https://github.com/creationix/nvm.git'
             version: "{{ nvm_version }}"
+            recursive: no
           when: "'/git' in mg_cmd.stdout"
 
         - name: Add NVM to nvm_profile


### PR DESCRIPTION
- Fixed malformed git repository URL by removing extra '.nvm' suffix
- Added recursive: no to prevent submodule initialization issues
- Resolves git clone failures with 'URL rejected: Malformed input' error